### PR TITLE
[Fix] SchedulingService에 환경 제어를 위한 is_dev 매개변수 추가

### DIFF
--- a/functions/lambda_handlers/scheduling/dodam.py
+++ b/functions/lambda_handlers/scheduling/dodam.py
@@ -27,7 +27,7 @@ def dodam_schedule_view(event, context):
         scheduling_service = container.get_scheduling_service()
 
         results:ParsedMenuData = asyncio.run(scheduling_service.process_weekly_schedule_general(
-            RestaurantType.DODAM, weekdays
+            RestaurantType.DODAM, weekdays,is_dev=False
         ))
 
         logger.info("도담식당 주간 스케줄 완료")

--- a/functions/lambda_handlers/scheduling/faculty.py
+++ b/functions/lambda_handlers/scheduling/faculty.py
@@ -27,7 +27,7 @@ def faculty_schedule_view(event, context):
         scheduling_service = container.get_scheduling_service()
 
         results:ParsedMenuData = asyncio.run(scheduling_service.process_weekly_schedule_general(
-            RestaurantType.FACULTY, weekdays
+            RestaurantType.FACULTY, weekdays, is_dev=False
         ))
 
         logger.info("교직원식당 주간 스케줄 완료")

--- a/functions/lambda_handlers/scheduling/haksik.py
+++ b/functions/lambda_handlers/scheduling/haksik.py
@@ -27,7 +27,7 @@ def haksik_schedule_view(event, context):
         scheduling_service = container.get_scheduling_service()
 
         results:ParsedMenuData = asyncio.run(scheduling_service.process_weekly_schedule_general(
-            RestaurantType.HAKSIK, weekdays
+            RestaurantType.HAKSIK, weekdays, is_dev=False
         ))
 
         logger.info("학생식당 주간 스케줄 완료")

--- a/functions/lambda_handlers/scraping/dodam.py
+++ b/functions/lambda_handlers/scraping/dodam.py
@@ -2,7 +2,7 @@ import asyncio
 import logging
 
 from functions.shared.models.exceptions import (
-    HolidayException, MenuFetchException, MenuParseException
+    HolidayException, MenuFetchException, MenuParseException, WeirdRestaurantNameException
 )
 from functions.shared.models.model import RestaurantType, ParsedMenuData, ResponseBuilder
 
@@ -39,7 +39,7 @@ def dodam_view(event, context):
             message=f"{RestaurantType.DODAM.korean_name} 메뉴 처리 완료"
         )
 
-    except (HolidayException, MenuFetchException, MenuParseException, WeirdRestaurantName) as e:
+    except (HolidayException, MenuFetchException, MenuParseException,WeirdRestaurantNameException) as e:
         logger.error(f"도담식당 도메인 오류: {e}")
 
         # Slack 에러 알림

--- a/functions/shared/services/scheduling_service.py
+++ b/functions/shared/services/scheduling_service.py
@@ -15,7 +15,8 @@ class SchedulingService:
         self.notification_service = notification_service
         self.scraping_service = scraping_service
 
-    async def process_weekly_schedule_general(self, restaurant_type: RestaurantType, weekdays: List[str]) -> List[
+    async def process_weekly_schedule_general(self, restaurant_type: RestaurantType, weekdays: List[str],
+                                              is_dev: bool) -> List[
         ParsedMenuData]:
         """일반 식당 주간 스케줄 처리 (도담, 학생, 교직원)"""
         logger.info(f"{restaurant_type.korean_name} 주간 스케줄 처리 시작: {weekdays}")
@@ -27,18 +28,19 @@ class SchedulingService:
         # 하부에서는 예외처리 하지 않는다. 모든 예외는 이곳에서 처리한다. 이는 비즈니스의 로직의 특성상 스케줄링은 일부라도 성공해야만 한다.
         for date in weekdays:
             try:
-                parsed_menu = await scraping_service.scrape_and_process(date, restaurant_type)
+                parsed_menu = await scraping_service.scrape_and_process(date, restaurant_type,is_dev=is_dev)
                 parsed_menus.append(parsed_menu)
                 await self.notification_service.send_menu_notification(parsed_menu)
 
             except (HolidayException, MenuFetchException, MenuParseException,
-                WeirdRestaurantNameException, MenuPostException) as e:
+                    WeirdRestaurantNameException, MenuPostException) as e:
                 logger.warning(f"{restaurant_type.korean_name}({date}) 처리 실패: {type(e).__name__} - {e}")
                 await self.notification_service.send_error_notification(e, date, restaurant_type)
                 continue
             except Exception as e:
                 # 예상치 못한 예외 - 더 자세한 로깅
-                logger.error(f"{restaurant_type.korean_name}({date}) 예상치 못한 오류: {type(e).__name__} - {e}", exc_info=True)
+                logger.error(f"{restaurant_type.korean_name}({date}) 예상치 못한 오류: {type(e).__name__} - {e}",
+                             exc_info=True)
                 await self.notification_service.send_error_notification(e, date, restaurant_type)
                 continue
         # Slack 알림 전송
@@ -56,7 +58,7 @@ class SchedulingService:
         logger.info(f"{restaurant_type.korean_name} 주간 스케줄 처리 완료")
         return parsed_menus
 
-    async def process_weekly_schedule_dormitory(self, weekdays: List[str]) -> List[ParsedMenuData]:
+    async def process_weekly_schedule_dormitory(self, weekdays: List[str],is_dev:bool) -> List[ParsedMenuData]:
         """기숙사식당 주간 스케줄 처리 (주간 단위)"""
         restaurant_type = RestaurantType.DORMITORY
         logger.info(f"{restaurant_type.korean_name} 주간 스케줄 처리 시작: {weekdays}")
@@ -66,7 +68,7 @@ class SchedulingService:
         date = weekdays[0]  # 월요일 날짜를 기반으로 일주일 전체가 스크래핑 됨
 
         try:
-            parsed_menus: List[ParsedMenuData] = await scraping_service.scrape_and_process_dormitory(date)
+            parsed_menus: List[ParsedMenuData] = await scraping_service.scrape_and_process_dormitory(date,is_dev=is_dev)
 
             for parsed_menu in parsed_menus:
                 if parsed_menu.error_slots:
@@ -88,8 +90,6 @@ class SchedulingService:
                 "error": str(e)
             }
             logger.error(f"{restaurant_type.korean_name} {date} 처리 실패: {e}")
-
-        
 
         logger.info(f"{restaurant_type.korean_name} 주간 스케줄 처리 완료")
         return results


### PR DESCRIPTION

# PR 본문

## 작업 내용

SchedulingService의 메소드들에 `is_dev` 매개변수를 추가하여 개발 환경과 프로덕션 환경을 구분할 수 있도록 개선했습니다. 이를 통해 스크래핑 서비스 호출 시 환경별로 다른 동작을 할 수 있게 되었습니다.

## 작업 방법

1. `SchedulingService` 클래스의 주요 메소드들에 `is_dev: bool` 매개변수 추가
2. 각 Lambda 핸들러에서 해당 메소드 호출 시 `is_dev=False` 명시적으로 전달
3. 스크래핑 서비스 호출 시 `is_dev` 매개변수 전달하도록 수정

## 변경 사항

### Lambda 핸들러 수정
- `functions/lambda_handlers/scheduling/dodam.py`
  - `process_weekly_schedule_general()` 호출 시 `is_dev=False` 추가
- `functions/lambda_handlers/scheduling/faculty.py`
  - `process_weekly_schedule_general()` 호출 시 `is_dev=False` 추가
- `functions/lambda_handlers/scheduling/haksik.py`
  - `process_weekly_schedule_general()` 호출 시 `is_dev=False` 추가

### 스크래핑 핸들러 수정
- `functions/lambda_handlers/scraping/dodam.py`
  - import 구문에서 `WeirdRestaurantName` → `WeirdRestaurantNameException` 오타 수정

### SchedulingService 수정
- `functions/shared/services/scheduling_service.py`
  - `process_weekly_schedule_general()` 메소드에 `is_dev: bool` 매개변수 추가
  - `process_weekly_schedule_dormitory()` 메소드에 `is_dev: bool` 매개변수 추가
  - 스크래핑 서비스 호출 시 `is_dev` 매개변수 전달
  - 코드 포매팅 개선 (일부 라인의 들여쓰기 및 줄바꿈 정리)

## 참고 사항

- 현재 모든 Lambda 핸들러에서는 `is_dev=False`로 설정되어 프로덕션 모드로 동작합니다
- 개발 환경에서 테스트할 때는 해당 값을 `True`로 변경하여 사용할 수 있습니다
- 이 변경사항은 기존 기능에 영향을 주지 않으며, 향후 환경별 구분이 필요한 로직 추가 시 활용할 수 있습니다
- `WeirdRestaurantNameException` import 오타도 함께 수정되었습니다