### PR TITLE
[Fix] fix lambda handler parameter parsing issue close #13

### DIFF
--- a/functions/lambda_handlers/scheduling/dodam.py
+++ b/functions/lambda_handlers/scheduling/dodam.py
@@ -11,9 +11,8 @@ def dodam_schedule_view(event, context):
     """도담식당 주간 스케줄 뷰"""
     try:
         # 1. 파라미터 추출
-        delayed_schedule = False
-        if event.get("queryStringParameters"):
-            delayed_schedule = bool(event["queryStringParameters"].get("delayed_schedule"))
+        query_params = event.get("queryStringParameters") or {}
+        delayed_schedule = query_params.get("delayed_schedule", "").lower() == 'true'
 
         logger.info(f"도담식당 주간 스케줄 시작 (delayed: {delayed_schedule})")
 

--- a/functions/lambda_handlers/scheduling/dormitory.py
+++ b/functions/lambda_handlers/scheduling/dormitory.py
@@ -12,9 +12,8 @@ def dormitory_schedule_view(event, context):
     """기숙사식당 주간 스케줄 뷰"""
     try:
         # 1. 파라미터 추출
-        delayed_schedule = False
-        if event.get("queryStringParameters"):
-            delayed_schedule = bool(event["queryStringParameters"].get("delayed_schedule"))
+        query_params = event.get("queryStringParameters") or {}
+        delayed_schedule = query_params.get("delayed_schedule", "").lower() == 'true'
 
         logger.info(f"기숙사식당 주간 스케줄 시작 (delayed: {delayed_schedule})")
 

--- a/functions/lambda_handlers/scheduling/faculty.py
+++ b/functions/lambda_handlers/scheduling/faculty.py
@@ -11,9 +11,8 @@ def faculty_schedule_view(event, context):
     """교직원식당 주간 스케줄 뷰"""
     try:
         # 1. 파라미터 추출
-        delayed_schedule = False
-        if event.get("queryStringParameters"):
-            delayed_schedule = bool(event["queryStringParameters"].get("delayed_schedule"))
+        query_params = event.get("queryStringParameters") or {}
+        delayed_schedule = query_params.get("delayed_schedule", "").lower() == 'true'
 
         logger.info(f"교직원식당 주간 스케줄 시작 (delayed: {delayed_schedule})")
 

--- a/functions/lambda_handlers/scheduling/haksik.py
+++ b/functions/lambda_handlers/scheduling/haksik.py
@@ -11,9 +11,8 @@ def haksik_schedule_view(event, context):
     """학생식당 주간 스케줄 뷰"""
     try:
         # 1. 파라미터 추출
-        delayed_schedule = False
-        if event.get("queryStringParameters"):
-            delayed_schedule = bool(event["queryStringParameters"].get("delayed_schedule"))
+        query_params = event.get("queryStringParameters") or {}
+        delayed_schedule = query_params.get("delayed_schedule", "").lower() == 'true'
 
         logger.info(f"학생식당 주간 스케줄 시작 (delayed: {delayed_schedule})")
 


### PR DESCRIPTION
## 작업 내용
queryStringParameters의 delayed_schedule 파라미터를 올바르게 boolean으로 파싱하도록 수정
## 작업 방법
bool() 함수 대신 문자열 비교를 통해 'true' 값만 True로 인식하도록 변경
## 변경 사항
delayed_schedule = bool(event["queryStringParameters"].get("delayed_schedule")) → query_params = event.get("queryStringParameters") or {}; delayed_schedule = query_params.get("delayed_schedule", "").lower() == 'true'
## 참고 사항
Python의 bool('false')는 True를 반환하므로 문자열 파라미터 파싱 시 주의 필요