### PR TITLE
[Fix] fix dormitory to scrap weekend(saturday,sunday) close #16

### DIFF
--- a/functions/lambda_handlers/scheduling/dormitory.py
+++ b/functions/lambda_handlers/scheduling/dormitory.py
@@ -19,7 +19,8 @@ def dormitory_schedule_view(event, context):
 
         # 2. 날짜 목록 결정
         from functions.shared.utils.date_utils import get_next_weekdays, get_current_weekdays
-        weekdays = get_current_weekdays() if delayed_schedule else get_next_weekdays()
+        # 250921 이후, 기숙사는 주말도 추가되었음
+        weekdays = get_current_weekdays(include_weekend=True) if delayed_schedule else get_next_weekdays(include_weekend=True)
 
         # 3. 기숙사 전용 스케줄링 서비스 사용
         from functions.config.dependencies import get_container

--- a/functions/shared/utils/date_utils.py
+++ b/functions/shared/utils/date_utils.py
@@ -2,24 +2,28 @@ from datetime import datetime, timedelta
 
 from pytz import timezone
 
+WEEKDAYS_COUNT = 5  # 평일 (월~금)
+FULL_WEEK_COUNT = 7  # 전체 주 (월~일)
 
-def get_next_weekdays():
+
+def get_next_weekdays(include_weekend=False):
     seoul_tz = timezone("Asia/Seoul")
     current_date = datetime.now(seoul_tz).replace(hour=0, minute=0, second=0, microsecond=0)
 
     # 현재 요일이 월요일이면 7을, 그렇지 않으면 다음 주 월요일까지의 날짜 계산
     weekday = current_date.weekday()  # 현재 요일 (0: 월요일, 1: 화요일, ..., 6: 일요일)
     current_monday = current_date - timedelta(days=weekday)
-    next_monday = current_monday + timedelta(days=7)
+    next_monday = current_monday + timedelta(days=FULL_WEEK_COUNT)
 
     # 날짜 범위 내의 날짜를 생성하여 리스트에 추가
-    date_list = [next_monday + timedelta(days=i) for i in range(5)]
+    days_count = FULL_WEEK_COUNT if include_weekend else WEEKDAYS_COUNT
+    date_list = [next_monday + timedelta(days=i) for i in range(days_count)]
     date_list_formatted = [date.strftime("%Y%m%d") for date in date_list]
 
     return date_list_formatted
 
 
-def get_current_weekdays():
+def get_current_weekdays(include_weekend=False):
     # 해당하는 날짜를 받으면 그 주의 월요일부터 금요일까지의 날짜를 반환
     seoul_tz = timezone("Asia/Seoul")
     current_date = datetime.now(seoul_tz).replace(hour=0, minute=0, second=0, microsecond=0)
@@ -28,7 +32,8 @@ def get_current_weekdays():
     weekday = current_date.weekday()  # 현재 요일 (0: 월요일, 1: 화요일, ..., 6: 일요일)
     current_monday = current_date - timedelta(days=weekday)
 
-    date_list = [current_monday + timedelta(days=i) for i in range(5)]
+    days_count = FULL_WEEK_COUNT if include_weekend else WEEKDAYS_COUNT
+    date_list = [current_monday + timedelta(days=i) for i in range(days_count)]
     date_list_formatted = [date.strftime("%Y%m%d") for date in date_list]
 
     return date_list_formatted


### PR DESCRIPTION
## 작업 내용
#16 

## 작업 방법

  - date_utils.py의 날짜 함수에 include_weekend 파라미터 추가
  - 매직넘버(5, 7)를 상수(WEEKDAYS_COUNT, FULL_WEEK_COUNT)로 관리
  - 기숙사 스케줄에서 include_weekend=True로 호출

## 변경 사항

  functions/shared/utils/date_utils.py
  - 상수 추가: WEEKDAYS_COUNT = 5, FULL_WEEK_COUNT = 7
  - get_next_weekdays(include_weekend=False) 파라미터 추가
  - get_current_weekdays(include_weekend=False) 파라미터 추가

  functions/lambda_handlers/scheduling/dormitory.py
  - 날짜 조회 시 include_weekend=True 적용

## 참고 사항

  - 다른 식당(학식, 도담, 교직원)은 기존처럼 평일(월~금)만 조회
  - 기본값이 False이므로 기존 코드 호환성 유지