### PR TITLE
feat(dormitory): 빈 메뉴 재시도(Step Functions) + 멱등성 + 무음 실패 경보

### DIFF
--- a/functions/lambda_handlers/notify_failure.py
+++ b/functions/lambda_handlers/notify_failure.py
@@ -1,0 +1,34 @@
+import asyncio
+import json
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def notify_failure_handler(event, context):
+    logger.info(f"NotifyFailure 이벤트 수신: {json.dumps(event, ensure_ascii=False, default=str)}")
+
+    error_info = event.get("error", {})
+    error_type = error_info.get("Error", "UnknownError")
+    error_cause = error_info.get("Cause", str(error_info))
+
+    from functions.config.dependencies import get_container
+    notification_service = get_container().get_notification_service()
+
+    final_error = Exception(
+        f"[기숙사 최종 실패] 재시도 후에도 메뉴를 가져오지 못했습니다.\n"
+        f"에러 타입: {error_type}\n"
+        f"상세: {error_cause}"
+    )
+
+    asyncio.run(notification_service.send_error_notification(exception=final_error))
+
+    logger.info("최종 실패 Slack 알림 전송 완료")
+
+    return {
+        'statusCode': 200,
+        'body': json.dumps({'message': 'final failure notified', 'error_type': error_type}, ensure_ascii=False)
+    }
+
+
+lambda_handler = notify_failure_handler

--- a/functions/lambda_handlers/notify_failure.py
+++ b/functions/lambda_handlers/notify_failure.py
@@ -13,6 +13,7 @@ def notify_failure_handler(event, context):
     error_cause = error_info.get("Cause", str(error_info))
 
     from functions.config.dependencies import get_container
+    from functions.shared.models.model import RestaurantType
     notification_service = get_container().get_notification_service()
 
     final_error = Exception(
@@ -21,7 +22,10 @@ def notify_failure_handler(event, context):
         f"상세: {error_cause}"
     )
 
-    asyncio.run(notification_service.send_error_notification(exception=final_error))
+    asyncio.run(notification_service.send_error_notification(
+        exception=final_error,
+        restaurant_type=RestaurantType.DORMITORY
+    ))
 
     logger.info("최종 실패 Slack 알림 전송 완료")
 

--- a/functions/lambda_handlers/scheduling/dodam.py
+++ b/functions/lambda_handlers/scheduling/dodam.py
@@ -26,7 +26,7 @@ def dodam_schedule_view(event, context):
         container = get_container()
         scheduling_service = container.get_scheduling_service()
 
-        results: ParsedMenuData = asyncio.run(scheduling_service.process_weekly_schedule_general(
+        results: list[ParsedMenuData] = asyncio.run(scheduling_service.process_weekly_schedule_general(
             RestaurantType.DODAM, weekdays, is_dev=False
         ))
 
@@ -35,7 +35,7 @@ def dodam_schedule_view(event, context):
         return {
             'statusCode': 200,
             'headers': {'Content-Type': 'application/json; charset=utf-8'},
-            'body': json.dumps(results.to_dict(), ensure_ascii=False)
+            'body': json.dumps([r.to_dict() for r in results], ensure_ascii=False)
         }
 
     except Exception as e:

--- a/functions/lambda_handlers/scheduling/dormitory.py
+++ b/functions/lambda_handlers/scheduling/dormitory.py
@@ -3,7 +3,8 @@ import json
 import logging
 from typing import List
 
-from functions.shared.models.model import ParsedMenuData
+from functions.shared.models.exceptions import RetryableEmptyMenuError
+from functions.shared.models.model import ParsedMenuData, RestaurantType
 from functions.shared.utils.date_utils import WeekType
 
 logger = logging.getLogger(__name__)
@@ -11,46 +12,33 @@ logger = logging.getLogger(__name__)
 
 def dormitory_schedule_view(event, context):
     """기숙사식당 주간 스케줄 뷰"""
-    try:
-        # 1. 파라미터 추출
-        query_params = event.get("queryStringParameters") or {}
-        delayed_schedule = query_params.get("delayed_schedule", "").lower() == 'true'
+    query_params = event.get("queryStringParameters") or {}
+    delayed_schedule = query_params.get("delayed_schedule", "").lower() == 'true'
 
-        logger.info(f"기숙사식당 주간 스케줄 시작 (delayed: {delayed_schedule})")
+    logger.info(f"기숙사식당 주간 스케줄 시작 (delayed: {delayed_schedule})")
 
-        # 2. 날짜 목록 결정
-        from functions.shared.utils.date_utils import get_current_weekdays
-        # 250921 이후, 기숙사는 주말도 추가되었음, 다만 로직 문제로 날짜 변경됬을 시  functions/shared/scrapers/dormitory_scraper.py scrape_menu()를 확인해서 함께 변경해야함... :(
-        weekdays = get_current_weekdays(week_type=WeekType.FULL_WEEK)
+    from functions.shared.utils.date_utils import get_current_weekdays
+    # 250921 이후, 기숙사는 주말도 추가되었음, 다만 로직 문제로 날짜 변경됬을 시  functions/shared/scrapers/dormitory_scraper.py scrape_menu()를 확인해서 함께 변경해야함... :(
+    weekdays = get_current_weekdays(week_type=WeekType.FULL_WEEK)
 
-        # 3. 기숙사 전용 스케줄링 서비스 사용
-        from functions.config.dependencies import get_container
-        container = get_container()
-        scheduling_service = container.get_scheduling_service()
+    from functions.config.dependencies import get_container
+    container = get_container()
+    scheduling_service = container.get_scheduling_service()
 
-        results: List[ParsedMenuData] = asyncio.run(
-            scheduling_service.process_weekly_schedule_dormitory(weekdays, is_dev=False))
-        return_results = [result.to_dict() for result in results]
+    results: List[ParsedMenuData] = asyncio.run(
+        scheduling_service.process_weekly_schedule_dormitory(weekdays, is_dev=False))
 
-        logger.info("기숙사식당 주간 스케줄 완료")
+    # 결과가 비면(사이트 미게시) 예외를 던져 Step Functions가 몇 시간 뒤 재시도하도록 한다
+    if not results:
+        raise RetryableEmptyMenuError(target_date=weekdays[0], restaurant_type=RestaurantType.DORMITORY)
 
-        return {
-            'statusCode': 200,
-            'headers': {'Content-Type': 'application/json; charset=utf-8'},
-            'body': json.dumps(return_results, ensure_ascii=False)
-        }
+    logger.info("기숙사식당 주간 스케줄 완료")
 
-    except Exception as e:
-        logger.error(f"기숙사식당 스케줄링 오류: {e}", exc_info=True)
-
-        return {
-            'statusCode': 500,
-            'headers': {'Content-Type': 'application/json; charset=utf-8'},
-            'body': json.dumps({
-                'error': 'Internal server error',
-                'restaurant': 'DORMITORY'
-            }, ensure_ascii=False)
-        }
+    return {
+        'statusCode': 200,
+        'headers': {'Content-Type': 'application/json; charset=utf-8'},
+        'body': json.dumps([r.to_dict() for r in results], ensure_ascii=False)
+    }
 
 
 # AWS Lambda 핸들러

--- a/functions/lambda_handlers/scheduling/faculty.py
+++ b/functions/lambda_handlers/scheduling/faculty.py
@@ -25,7 +25,7 @@ def faculty_schedule_view(event, context):
         container = get_container()
         scheduling_service = container.get_scheduling_service()
 
-        results: ParsedMenuData = asyncio.run(scheduling_service.process_weekly_schedule_general(
+        results: list[ParsedMenuData] = asyncio.run(scheduling_service.process_weekly_schedule_general(
             RestaurantType.FACULTY, weekdays, is_dev=False
         ))
 
@@ -34,7 +34,7 @@ def faculty_schedule_view(event, context):
         return {
             'statusCode': 200,
             'headers': {'Content-Type': 'application/json; charset=utf-8'},
-            'body': json.dumps(results.to_dict(), ensure_ascii=False)
+            'body': json.dumps([r.to_dict() for r in results], ensure_ascii=False)
         }
 
     except Exception as e:

--- a/functions/lambda_handlers/scheduling/haksik.py
+++ b/functions/lambda_handlers/scheduling/haksik.py
@@ -25,7 +25,7 @@ def haksik_schedule_view(event, context):
         container = get_container()
         scheduling_service = container.get_scheduling_service()
 
-        results: ParsedMenuData = asyncio.run(scheduling_service.process_weekly_schedule_general(
+        results: list[ParsedMenuData] = asyncio.run(scheduling_service.process_weekly_schedule_general(
             RestaurantType.HAKSIK, weekdays, is_dev=False
         ))
 
@@ -34,7 +34,7 @@ def haksik_schedule_view(event, context):
         return {
             'statusCode': 200,
             'headers': {'Content-Type': 'application/json; charset=utf-8'},
-            'body': json.dumps(results.to_dict(), ensure_ascii=False)
+            'body': json.dumps([r.to_dict() for r in results], ensure_ascii=False)
         }
 
     except Exception as e:

--- a/functions/shared/models/exceptions.py
+++ b/functions/shared/models/exceptions.py
@@ -63,3 +63,12 @@ class MenuPostException(BaseRestaurantException):
         note = details
         super().__init__(target_date, restaurant_type, note)
         self.details = details
+
+
+class RetryableEmptyMenuError(BaseRestaurantException):
+    """스크래핑 결과가 비어 있어(사이트 미게시) Step Functions 재시도가 필요한 예외"""
+
+    def __init__(self, target_date: str, restaurant_type: RestaurantType, scraped_days: int = 0):
+        note = f"스크래핑 결과가 비어 있습니다. (수집 일수: {scraped_days}) 사이트 메뉴 미게시로 추정되어 재시도가 필요합니다."
+        super().__init__(target_date, restaurant_type, note)
+        self.scraped_days = scraped_days

--- a/functions/shared/repositories/scrapers/dormitory_scraper.py
+++ b/functions/shared/repositories/scrapers/dormitory_scraper.py
@@ -32,7 +32,8 @@ class DormitoryScraper(MenuScraperInterface):
             html_content = await self._fetch_menu_html(date)
 
             # HTML 파싱하여 메뉴 데이터 추출
-            raw_menu_list = self._parse_html_to_raw_menu_data(html_content)[:7] # TODO: 추후 주말 기숙사 식당 추가 시 슬라이싱 제거 제거하는 거랑 관계 없이 여기서 이렇게 하면 안되는데...
+            base_year = datetime.strptime(date, '%Y%m%d').year
+            raw_menu_list = self._parse_html_to_raw_menu_data(html_content, base_year)[:7] # TODO: 추후 주말 기숙사 식당 추가 시 슬라이싱 제거 제거하는 거랑 관계 없이 여기서 이렇게 하면 안되는데...
             logger.info(f"기숙사식당 주간 메뉴 스크래핑 완료: {len(raw_menu_list)}일치")
         except Exception as e:
             menu_fetch_exception = MenuFetchException(
@@ -58,7 +59,7 @@ class DormitoryScraper(MenuScraperInterface):
                 response.raise_for_status()
                 return await response.text()
 
-    def _parse_html_to_raw_menu_data(self, html_content: str) -> List[RawMenuData]:
+    def _parse_html_to_raw_menu_data(self, html_content: str, base_year: int) -> List[RawMenuData]:
         """HTML을 파싱하여 RawMenuData 리스트로 변환"""
         # HTML에서 테이블 추출
         table_data = self._extract_table_from_html(html_content)
@@ -67,7 +68,7 @@ class DormitoryScraper(MenuScraperInterface):
         structured_data = self._structure_table_data(table_data)
 
         # 구조화된 데이터를 RawMenuData로 변환
-        return self._convert_to_raw_menu_data(structured_data)
+        return self._convert_to_raw_menu_data(structured_data, base_year)
 
     def _extract_table_from_html(self, html_content: str) -> List[List[str]]:
         """HTML에서 테이블을 추출하여 2D 리스트로 반환"""
@@ -106,6 +107,9 @@ class DormitoryScraper(MenuScraperInterface):
             elif header in ['조식', '중식', '석식']:
                 meal_col_indices[header] = i
 
+        if date_col_idx is None:
+            raise ValueError(f"'날짜' 컬럼을 찾을 수 없습니다. 테이블 구조 변경 의심: headers={headers}")
+
         return date_col_idx, meal_col_indices
 
     def _process_table_row(self, row: List[str], date_col_idx: int, meal_col_indices: Dict[str, int]) -> Dict[str, any]:
@@ -120,13 +124,13 @@ class DormitoryScraper(MenuScraperInterface):
 
         return row_data
 
-    def _convert_to_raw_menu_data(self, structured_data: List[Dict[str, any]]) -> List[RawMenuData]:
+    def _convert_to_raw_menu_data(self, structured_data: List[Dict[str, any]], base_year: int) -> List[RawMenuData]:
         """구조화된 데이터를 RawMenuData 리스트로 변환"""
         raw_menu_list = []
 
         for row_data in structured_data:
             # 날짜 파싱
-            date_str = self._parse_date(str(row_data['날짜']))
+            date_str = self._parse_date(str(row_data['날짜']), base_year)
             if not date_str:
                 continue
 
@@ -158,14 +162,13 @@ class DormitoryScraper(MenuScraperInterface):
 
         return menu_texts
 
-    def _parse_date(self, date_str: str) -> str:
+    def _parse_date(self, date_str: str, base_year: int) -> str:
         """날짜 문자열을 YYYYMMDD 형식으로 변환"""
         try:
             # "2024-03-25" 또는 "03-25" 형식 처리
             clean_date = date_str.split()[0].replace("-", "")
-            if len(clean_date) == 4:  # MM-DD 형태
-                current_year = datetime.now().year
-                clean_date = f"{current_year}{clean_date}"
+            if len(clean_date) == 4:  # MM-DD 형태 → 연도는 스크래핑 기준일(base_year)을 사용
+                clean_date = f"{base_year}{clean_date}"
             return clean_date if len(clean_date) == 8 else ""
         except:
             return ""

--- a/functions/shared/services/scheduling_service.py
+++ b/functions/shared/services/scheduling_service.py
@@ -63,33 +63,23 @@ class SchedulingService:
         restaurant_type = RestaurantType.DORMITORY
         logger.info(f"{restaurant_type.korean_name} 주간 스케줄 처리 시작: {weekdays}")
 
-        results = {}
-        scraping_service = self.scraping_service
         date = weekdays[0]  # 월요일 날짜를 기반으로 일주일 전체가 스크래핑 됨
 
-        try:
-            parsed_menus: List[ParsedMenuData] = await scraping_service.scrape_and_process_dormitory(date,is_dev=is_dev)
+        # 예외를 삼키지 않고 호출부(핸들러/Step Functions)로 전파한다. 진짜 빈 결과만 핸들러가 재시도 대상으로 분류한다
+        parsed_menus = await self.scraping_service.scrape_and_process_dormitory(date, is_dev=is_dev)
 
-            for parsed_menu in parsed_menus:
-                if parsed_menu.error_slots:
-                    logger.info(
-                        f"{restaurant_type.korean_name}({parsed_menu.date}) 부분 실패: {parsed_menu.error_slots}")
-                    for slot, error in parsed_menu.error_slots.items():
-                        await self.notification_service.send_error_notification(
-                            exception=Exception(f"[{slot}] {error}"),
-                            date=parsed_menu.date,
-                            restaurant_type=restaurant_type
-                        )
-                else:
-                    await self.notification_service.send_menu_notification(parsed_menu)
-
-            return parsed_menus
-        except Exception as e:
-            results[date] = {
-                "success": False,
-                "error": str(e)
-            }
-            logger.error(f"{restaurant_type.korean_name} {date} 처리 실패: {e}")
+        for parsed_menu in parsed_menus:
+            if parsed_menu.error_slots:
+                logger.info(
+                    f"{restaurant_type.korean_name}({parsed_menu.date}) 부분 실패: {parsed_menu.error_slots}")
+                for slot, error in parsed_menu.error_slots.items():
+                    await self.notification_service.send_error_notification(
+                        exception=Exception(f"[{slot}] {error}"),
+                        date=parsed_menu.date,
+                        restaurant_type=restaurant_type
+                    )
+            else:
+                await self.notification_service.send_menu_notification(parsed_menu)
 
         logger.info(f"{restaurant_type.korean_name} 주간 스케줄 처리 완료")
-        return results
+        return parsed_menus

--- a/functions/shared/services/scraping_service.py
+++ b/functions/shared/services/scraping_service.py
@@ -39,9 +39,13 @@ class ScrapingService:
         # 1. 스크래핑 단계 (주간)
         parsed_menus = await self.scrape_dormitory_weekly(date)
 
-        # 2. API 전송 단계 (각 날짜별)
+        # 2. API 전송 단계 (각 날짜별) - 한 날짜의 전송 실패가 나머지 주를 중단시키지 않도록 격리
         for parsed_menu in parsed_menus:
-            await self.send_to_api(parsed_menu, is_dev)
+            try:
+                await self.send_to_api(parsed_menu, is_dev)
+            except MenuPostException as e:
+                logger.error(f"기숙사식당({parsed_menu.date}) API 전송 실패: {e}")
+                continue
 
         logger.info(f"기숙사식당 주간 메뉴 처리 완료: {len(parsed_menus)}일치")
         return parsed_menus
@@ -116,7 +120,7 @@ class ScrapingService:
                 menu_items = parsed_menu.menus[slot]
 
                 await asyncio.gather(*[
-                    client.post_menu(date, restaurant, time_slot, menu_items, price)
+                    self._post_menu_if_absent(client, date, restaurant, time_slot, menu_items, price)
                     for client in clients
                 ])
                 sent_count += 1
@@ -150,6 +154,15 @@ class ScrapingService:
             f"API 전송 완료: {restaurant.korean_name} {date} - "
             f"{sent_count}개 슬롯 전송 성공, {len(failed_slots)}개 슬롯 실패"
         )
+
+    async def _post_menu_if_absent(self, client: SpringAPIClient, date: str, restaurant: RestaurantType,
+                                   time_slot: TimeSlot, menu_items: List[str], price: int) -> bool:
+        # 백엔드가 멱등하지 않으므로 재시도/수동 재호출 시 중복 POST를 막기 위해 먼저 존재 여부를 확인한다
+        existing = await client.get_menu(date, restaurant, time_slot)
+        if existing is not None:
+            logger.info(f"이미 등록된 메뉴, 전송 생략: {restaurant.english_name} {time_slot.english_name} {date}")
+            return True
+        return await client.post_menu(date, restaurant, time_slot, menu_items, price)
 
     # === 내부 구현 메서드들 ===
 

--- a/statemachine/dormitory-retry-workflow.asl.json
+++ b/statemachine/dormitory-retry-workflow.asl.json
@@ -1,0 +1,56 @@
+{
+  "Comment": "기숙사 메뉴 스케줄 재시도 워크플로우 - 빈 결과(미게시) 시 2시간 간격 최대 6회 시도",
+  "StartAt": "InvokeDormitory",
+  "States": {
+    "InvokeDormitory": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::lambda:invoke",
+      "Parameters": {
+        "FunctionName": "${DormitorySchedulingFunctionArn}",
+        "Payload": {
+          "httpMethod": "GET",
+          "path": "/schedule/dormitory",
+          "queryStringParameters": {
+            "delayed_schedule": "false"
+          }
+        }
+      },
+      "Retry": [
+        {
+          "ErrorEquals": [
+            "Lambda.ServiceException",
+            "Lambda.AWSLambdaException",
+            "Lambda.SdkClientException",
+            "Lambda.TooManyRequestsException"
+          ],
+          "IntervalSeconds": 2,
+          "MaxAttempts": 3,
+          "BackoffRate": 2.0
+        },
+        {
+          "ErrorEquals": ["RetryableEmptyMenuError"],
+          "IntervalSeconds": 7200,
+          "MaxAttempts": 5,
+          "BackoffRate": 1.0
+        }
+      ],
+      "Catch": [
+        {
+          "ErrorEquals": ["States.ALL"],
+          "ResultPath": "$.error",
+          "Next": "NotifyFinalFailure"
+        }
+      ],
+      "End": true
+    },
+    "NotifyFinalFailure": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::lambda:invoke",
+      "Parameters": {
+        "FunctionName": "${NotifyFailureFunctionArn}",
+        "Payload.$": "$"
+      },
+      "End": true
+    }
+  }
+}

--- a/template.yml
+++ b/template.yml
@@ -196,19 +196,32 @@ Resources:
           Properties:
             Path: /schedule/dormitory
             Method: get
-        # 매주 월요일 오전 8시에 자동 실행
+
+  NotifyFailureFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: ./
+      Handler: functions.lambda_handlers.notify_failure.lambda_handler
+      Layers:
+        - !Ref PythonRequirementsLayer
+
+  DormitoryRetryStateMachine:
+    Type: AWS::Serverless::StateMachine
+    Properties:
+      DefinitionUri: statemachine/dormitory-retry-workflow.asl.json
+      DefinitionSubstitutions:
+        DormitorySchedulingFunctionArn: !GetAtt DormitorySchedulingFunction.Arn
+        NotifyFailureFunctionArn: !GetAtt NotifyFailureFunction.Arn
+      Policies:
+        - LambdaInvokePolicy:
+            FunctionName: !Ref DormitorySchedulingFunction
+        - LambdaInvokePolicy:
+            FunctionName: !Ref NotifyFailureFunction
+      Events:
         WeeklySchedule:
           Type: Schedule
           Properties:
             Schedule: cron(0 23 ? * SUN *)
-            Input: |
-              {
-                "httpMethod": "GET",
-                "path": "/schedule/dormitory",
-                "queryStringParameters": {
-                  "delayed_schedule": "false"
-                }
-              }
 
 Outputs:
   FoodScrapperApi:


### PR DESCRIPTION
## 배경 / 문제 (실제 CloudWatch 로그 150일치 근거)

기숙사 스케줄러는 매주 월 08:00 KST에 **정상 실행**되지만, 그 시각엔 기숙사 사이트에 그 주 메뉴가 아직 **미게시** 상태라 스크래퍼가 0일치를 받습니다. 기존 코드는 빈 결과를 예외가 아닌 **성공으로 간주** → POST/Slack/DB 모두 없이 조용히 종료했습니다.

- 거의 격주로 0일치 발생(03-29, 04-05, 05-10, 05-17, 06-07, 06-21, 06-28...)
- 매번 오후에 수동 호출로 메꿔왔고, 6/21처럼 누락된 주도 있었음
- 에러도 안 떠서 인지 자체가 어려웠음

## 변경 내용

### 핵심 기능
- **빈 결과 → 재시도**: 0일치면 `RetryableEmptyMenuError`를 던져 Step Functions가 **2시간 간격 최대 6회(08~18시)** 재시도. 1일치 이상이면 즉시 성공(공휴일 주 4일도 정상 처리, 첫 발 빠른 DB 입력)
- **멱등성**: `_post_menu_if_absent` — POST 전 `get_menu`로 존재 확인 후 skip. 재시도/수동호출 중복 전송 방지 (백엔드 비멱등 + 단일 워커)
- **최종 실패 경보**: 재시도 소진 시 `NotifyFailure` Lambda가 Slack 경보 (재시도 중에는 안 보냄)
- 기숙사 EventBridge 트리거를 Lambda → StateMachine으로 이동
- 기숙사 처리에서 진짜 예외를 삼키지 않고 Step Functions Catch로 전파 (transient Lambda 에러는 별도 재시도)

### 함께 수정한 버그
- 일반식당(dodam/haksik/faculty) 핸들러 `list.to_dict()` 크래시 (4월 CloudWatch 에러 원인)
- 기숙사 주간 처리 dict 반환으로 인한 핸들러 크래시 + 날짜별 전송 격리
- 기숙사 스크래퍼: '날짜' 헤더 검증, 연도 추론을 `datetime.now()` → 입력 기준일

## 아키텍처

\`\`\`mermaid
flowchart TD
    EB["EventBridge<br/>cron(0 23 ? * SUN *)<br/>= 월 08:00 KST"] --> SM[Step Functions]
    SM --> INV[InvokeDormitory Lambda]
    INV --> SCRAPE{스크래핑 결과}

    SCRAPE -->|"≥ 1일치"| POST["슬롯별 POST<br/>(GET으로 이미 있으면 skip = 멱등성)"]
    POST --> OK["Slack 성공 알림 → 종료"]

    SCRAPE -->|"0일치 (미게시)"| ERR[RetryableEmptyMenuError]
    ERR --> WAIT["Wait 2h<br/>(최대 5회 재시도 = 총 6회: 08·10·12·14·16·18시)"]
    WAIT --> INV

    ERR -.->|"재시도 소진 / 기타 예외"| CATCH["Catch (States.ALL)"]
    CATCH --> NOTIFY["NotifyFailure Lambda<br/>→ Slack 최종 경보"]
\`\`\`

흐름 요약:
1. **첫 시도에 메뉴가 있으면** → 슬롯별로 POST(이미 등록됐으면 GET으로 확인 후 skip) → Slack 성공 → 종료
2. **0일치(사이트 미게시)면** → `RetryableEmptyMenuError` → 2시간 뒤 재시도(최대 6회)
3. **재시도 소진 또는 비재시도 예외** → Catch → `NotifyFailure` → Slack 최종 경보

## 검증
- \`sam validate\`: valid
- import / ASL JSON / lsp: 이상 없음
- 테스트: main 베이스라인과 동일 (사전 존재하던 실패 외 신규 회귀 0)
- Oracle 아키텍처 설계 + 코드 리뷰 반영 (예외 전파 수정, Lambda 서비스 예외 별도 재시도 추가)

## 배포 후 주의
- 다음 주 월요일 자동 실행에서 Step Functions 실행 이력으로 재시도 동작 확인 필요
- API Gateway 수동 경로(\`GET /schedule/dormitory\`)는 이제 빈 주에 502 반환 (의미상 실패, 운영용 경로라 허용)