### PR TITLE
feat: Slack에 영문 대표메뉴 표시

### DIFF
--- a/functions/clients.py
+++ b/functions/clients.py
@@ -33,6 +33,8 @@ _UNSAFE_DISPLAY_PATTERN = re.compile(
     r"<|>|://|www\.|critical|cause|secret|exception|traceback|provider\.",
     re.IGNORECASE,
 )
+
+
 def _safe_display(value: object) -> str | None:
     if not isinstance(value, str):
         return None
@@ -223,6 +225,7 @@ def format_slack_text(notification: Mapping[str, object]) -> str:
         return f"{header}\n⚠️ 최종 처리 실패: {reason}"
 
     menus = notification.get("menus")
+    main_menus = notification.get("main_menus")
     empty_reasons = notification.get("empty_reasons")
     if (
         isinstance(empty_reasons, Mapping)
@@ -268,6 +271,29 @@ def format_slack_text(notification: Mapping[str, object]) -> str:
             ]
             if safe_items:
                 safe_lines.append(f"• {slot}: {', '.join(safe_items)}")
+                raw_representatives = (
+                    main_menus.get(raw_slot) if isinstance(main_menus, Mapping) else None
+                )
+                safe_representatives: list[str] = []
+                if isinstance(raw_representatives, list):
+                    for representative in raw_representatives:
+                        if (
+                            not isinstance(representative, Mapping)
+                            or set(representative) != {"nameKo", "nameEn"}
+                        ):
+                            continue
+                        raw_name_ko = representative["nameKo"]
+                        raw_name_en = representative["nameEn"]
+                        if not isinstance(raw_name_ko, str) or not isinstance(
+                            raw_name_en, str
+                        ):
+                            continue
+                        name_ko = _safe_display(raw_name_ko)
+                        name_en = _safe_display(raw_name_en)
+                        if name_ko in safe_items and name_en is not None:
+                            safe_representatives.append(f"{name_ko} ({name_en})")
+                if safe_representatives:
+                    safe_lines.append(f"  ↳ 대표: {', '.join(safe_representatives)}")
 
     if isinstance(empty_reasons, Mapping):
         for raw_slot, raw_reason_code in sorted(

--- a/functions/handler.py
+++ b/functions/handler.py
@@ -250,9 +250,27 @@ def _menu_names(interpreted: Mapping[str, Any]) -> list[str]:
     return [item for item in value if isinstance(item, str)] if isinstance(value, list) else []
 
 
-def _main_menus(interpreted: Mapping[str, Any]) -> list[Mapping[str, Any]]:
-    value = interpreted.get("mainMenus", interpreted.get("main_menus", []))
-    return [item for item in value if isinstance(item, Mapping)] if isinstance(value, list) else []
+def _main_menus(
+    interpreted: Mapping[str, Any], menu_names: Sequence[str]
+) -> list[dict[str, str]]:
+    value = interpreted.get("mainMenus")
+    if not isinstance(value, list):
+        return []
+
+    validated: list[dict[str, str]] = []
+    for item in value:
+        if not isinstance(item, Mapping) or set(item) != {"nameKo", "nameEn"}:
+            continue
+        name_ko = item["nameKo"]
+        name_en = item["nameEn"]
+        if (
+            isinstance(name_ko, str)
+            and name_ko in menu_names
+            and isinstance(name_en, str)
+            and name_en.strip()
+        ):
+            validated.append({"nameKo": name_ko, "nameEn": name_en})
+    return validated
 
 
 async def _process_source_date(
@@ -297,7 +315,13 @@ async def _process_source_date(
             raise RetryableEmptyMenuError(target_date)
 
     summaries: dict[str, dict[str, Any]] = defaultdict(
-        lambda: {"menus": {}, "warnings": [], "errors": [], "empty_reasons": {}}
+        lambda: {
+            "menus": {},
+            "main_menus": {},
+            "warnings": [],
+            "errors": [],
+            "empty_reasons": {},
+        }
     )
     critical_failures: set[str] = set()
     environments = ("dev", "prod") if scheduled else ("dev",)
@@ -346,6 +370,9 @@ async def _process_source_date(
 
         menu_names = _menu_names(interpreted)
         summary["menus"][source_slot] = menu_names
+        main_menus = _main_menus(interpreted, menu_names)
+        if main_menus:
+            summary["main_menus"][source_slot] = main_menus
         policy = _slot_policy(config, source_slot)
         if policy is None:
             summary["warnings"].append(
@@ -360,7 +387,6 @@ async def _process_source_date(
             "price": price,
             "menuNames": menu_names,
         }
-        main_menus = _main_menus(interpreted)
         if main_menus:
             payload["mainMenus"] = main_menus
 

--- a/tests/integration/test_unified_runtime_integration.py
+++ b/tests/integration/test_unified_runtime_integration.py
@@ -108,7 +108,11 @@ def test_unified_handler_integrates_real_wave2_modules_at_external_boundaries():
         "mainMenus": [{"nameKo": "제육볶음", "nameEn": "Spicy Pork"}],
     }
     slack_text = slack_session.post.call_args.kwargs["json"]["text"]
-    assert slack_text == "🍽️ 도담식당 (20260713)\n• 중식1: 제육볶음"
+    assert slack_text == (
+        "🍽️ 도담식당 (20260713)\n"
+        "• 중식1: 제육볶음\n"
+        "  ↳ 대표: 제육볶음 (Spicy Pork)"
+    )
 
 
 def test_accepted_spring_is_not_replayed_when_slack_retries_exhaust(monkeypatch):

--- a/tests/test_exception_sanitization.py
+++ b/tests/test_exception_sanitization.py
@@ -104,3 +104,80 @@ def test_empty_slot_and_all_failure_stages_use_concise_allowlisted_labels():
         "⚠️ 중식5: 대표메뉴 매칭 실패"
     )
     assert SENTINEL not in text
+
+
+def test_dormitory_representatives_render_after_their_full_korean_slot_menu():
+    text = format_slack_text(
+        {
+            "type": "date_summary",
+            "date": "20260812",
+            "restaurant": "기숙사식당",
+            "menus": {
+                "석식1": ["닭갈비", "쌀밥", "배추김치", "요구르트"],
+                "중식1": ["돈까스", "우동", "단무지", "샐러드"],
+            },
+            "main_menus": {
+                "석식1": [
+                    {"nameKo": "닭갈비", "nameEn": "Spicy Stir-fried Chicken"},
+                    {"nameKo": "쌀밥", "nameEn": "Rice"},
+                ],
+                "중식1": [
+                    {"nameKo": "돈까스", "nameEn": "Pork Cutlet"},
+                    {"nameKo": "우동", "nameEn": "Udon"},
+                ],
+            },
+            "warnings": [],
+            "errors": [],
+        }
+    )
+
+    assert text == (
+        "🍽️ 기숙사식당 (20260812)\n"
+        "• 석식1: 닭갈비, 쌀밥, 배추김치, 요구르트\n"
+        "  ↳ 대표: 닭갈비 (Spicy Stir-fried Chicken), 쌀밥 (Rice)\n"
+        "• 중식1: 돈까스, 우동, 단무지, 샐러드\n"
+        "  ↳ 대표: 돈까스 (Pork Cutlet), 우동 (Udon)"
+    )
+
+
+def test_representative_menu_rejects_unsafe_or_noncanonical_entries():
+    text = format_slack_text(
+        {
+            "type": "date_summary",
+            "date": "20260812",
+            "restaurant": "도담식당",
+            "menus": {"중식1": ["제육볶음", "쌀밥"]},
+            "main_menus": {
+                "중식1": [
+                    {"nameKo": "제육볶음", "nameEn": SENTINEL},
+                    {
+                        "nameKo": "쌀밥",
+                        "nameEn": "Rice",
+                        "provider.Cause": SENTINEL,
+                    },
+                    {"nameKo": "쌀밥", "nameEn": "Rice"},
+                ]
+            },
+            "provider.mainMenus": [
+                {"nameKo": "공급자메뉴", "nameEn": SENTINEL}
+            ],
+            "warnings": [],
+            "errors": [],
+        }
+    )
+
+    assert text == (
+        "🍽️ 도담식당 (20260812)\n"
+        "• 중식1: 제육볶음, 쌀밥\n"
+        "  ↳ 대표: 쌀밥 (Rice)"
+    )
+    for unsafe in (
+        "<html>",
+        "SECRET_TOKEN",
+        "https://",
+        "provider.invalid",
+        "Cause",
+        "Critical",
+        "공급자메뉴",
+    ):
+        assert unsafe not in text

--- a/tests/test_unified_handler.py
+++ b/tests/test_unified_handler.py
@@ -300,6 +300,67 @@ def test_unmatched_main_menus_are_warned_once_without_reposting():
     ]
 
 
+def test_date_summary_maps_only_interpreted_main_menus_by_source_slot():
+    scrape = AsyncMock(
+        return_value=[
+            {
+                **_raw("20260713", "DODAM"),
+                "source_slot": "중식1",
+                "raw_text": "제육볶음 Spicy Pork 쌀밥",
+            },
+            {
+                **_raw("20260713", "DODAM"),
+                "source_slot": "석식1",
+                "raw_text": "된장찌개 Soybean Paste Stew",
+            },
+        ]
+    )
+    interpret = AsyncMock(
+        side_effect=[
+            {
+                "menuNames": ["제육볶음", "쌀밥"],
+                "mainMenus": [{"nameKo": "제육볶음", "nameEn": "Spicy Pork"}],
+            },
+            {"menuNames": ["된장찌개"], "mainMenus": []},
+        ]
+    )
+    publish = AsyncMock(
+        side_effect=[
+            _accepted(
+                unmatched=[
+                    {"nameKo": "공급자메뉴", "nameEn": "Provider Secret"}
+                ]
+            ),
+            _accepted(),
+        ]
+    )
+    slack = AsyncMock(return_value=True)
+
+    with (
+        patch.object(handler, "scrape", scrape),
+        patch.object(handler, "interpret_menu", interpret),
+        patch.object(handler, "publish_menu", publish),
+        patch.object(handler, "notify_slack", slack),
+    ):
+        response = handler.lambda_handler(
+            {"operation": "scrape_dodam", "target_date": "20260713"},
+            _Context(),
+        )
+
+    assert response["statusCode"] == 200
+    slack.assert_awaited_once()
+    assert slack.await_args is not None
+    notification = slack.await_args.args[1]
+    assert notification["menus"] == {
+        "중식1": ["제육볶음", "쌀밥"],
+        "석식1": ["된장찌개"],
+    }
+    assert notification["main_menus"] == {
+        "중식1": [{"nameKo": "제육볶음", "nameEn": "Spicy Pork"}]
+    }
+    assert "공급자메뉴" not in str(notification["main_menus"])
+
+
 def test_operation_loader_uses_flat_config_module_and_operation_policy():
     config = handler.load_operation_config("scrape_haksik")
     assert config is not None


### PR DESCRIPTION
## 변경 사항

Slack 일일 요약에 각 식단 슬롯의 영문 대표메뉴를 추가합니다.

- 한국어 전체 메뉴 유지
- `↳ 대표: nameKo (nameEn)` 형식으로 대표메뉴만 표시
- 전체 메뉴 번역은 하지 않음
- 처리 날짜당 Slack 1건 유지
- 휴일·실패 메시지 sanitization 유지

## 검증

- `141 passed`
- CI 통과